### PR TITLE
Add Morgenpost Online dbShortcut for morgenpost.de

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -136,7 +136,7 @@ const readers = {
     },
     provider: "bib-voebb.genios.de",
     providerParams: {
-      dbShortcut: 'BMP',
+      dbShortcut: 'BMP,BMPO',
       searchMask: '5601'
     }
   },


### PR DESCRIPTION
So far, not all articles on morgenpost.de are available since Morgenpost Online seems to be a separate publication with the shortcut `BMPO`. This is a naive attempt to fix that 😄 

Here's an example:
https://www.morgenpost.de/bezirke/pankow/article231817841/Vier-Jahre-Bauzeit-So-laeuft-die-Sanierung-des-Mauerparks.html

<img width="1014" alt="Bildschirmfoto 2021-03-17 um 14 34 40" src="https://user-images.githubusercontent.com/3079962/111475983-f47c5880-872d-11eb-8757-f758e8558dc9.png">
