### PR TITLE
save provider state as well

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -58,12 +58,14 @@ function restore () {
 function save () {
   const username = document.getElementById('username').value
   const password = document.getElementById('password').value
+  const provider = document.getElementById('provider').value
   const keepStats = document.getElementById('keepStats').checked
 
   const values = {
     username: username,
     password: password,
-    keepStats: keepStats
+    keepStats: keepStats,
+    provider: provider
   }
   if (!keepStats) {
     values.stats = {}


### PR DESCRIPTION
I tried to make this work for https://bib-potsdam.genios.de
The rest fails at `{ extract: '.divDocument pre.text', convert: 'preToParagraph' }` (with no error)
But this is definitely needed if you want to reuse it for other providers