### PR TITLE
Add WISO SSO and make user options provider dependent

### DIFF
--- a/options/options.html
+++ b/options/options.html
@@ -111,14 +111,10 @@
           <label for="provider">Bibliothek:</label>
           <select id="provider">
           </select>
-          <p>Wenn Ihr Browser Ihre Zugangsdaten nicht automatisch ausfüllt, können Sie hier die Daten hinterlegen.</p>
-
-          <label for="username">Nutzername:</label>
-          <input type="text" id="username"/>
-          <label for="password">Passwort:</label>
-          <input type="password" id="password"/>
+          <h3>Bibliotheks-Optionen</h3>
+          <div id="provider-options"></div>
           <p>
-            <small>Hinweis: Ihr Passwort wird im Klartext gespeichert, so dass es automatisch ausgefüllt werden kann.</small>
+            <small>Hinweis: Ihr Daten (inkl. Passwort) werden im Klartext gespeichert, so dass diese automatisch ausgefüllt werden können.</small>
           </p>
           <h3>Wollen Sie wissen, ob sich Ihr Bibliotheks-Konto lohnt?</h3>
           <p>

--- a/src/background.js
+++ b/src/background.js
@@ -1,9 +1,18 @@
 import Reader from '../src/reader.js'
+import update from './update.js'
 
 function openOptionsPage (details) {
   if (details.reason === 'install') {
     browser.runtime.openOptionsPage()
   }
+  else if (details.reason === 'update' && details.previousVersion) {
+    console.log("Extension was updated, running update scripts...")
+    update.run_update(
+      browser.runtime.getManifest().version,
+      details.previousVersion
+    )
+  }
+
 }
 
 browser.runtime.onInstalled.addListener(openOptionsPage)

--- a/src/providers.js
+++ b/src/providers.js
@@ -14,9 +14,13 @@ export default {
     },
     login: [
       { message: 'VÖBB-Konto wird eingeloggt...' },
-      { fill: { selector: 'input[name="L#AUSW"]', key: 'username' } },
-      { fill: { selector: 'input[name="LPASSW"]', key: 'password' } },
+      { fill: { selector: 'input[name="L#AUSW"]', providerKey: 'voebb.de.options.username' } },
+      { fill: { selector: 'input[name="LPASSW"]', providerKey: 'voebb.de.options.password' } },
       { click: 'input[name="LLOGIN"]' }
+    ],
+    options: [
+      { id: 'username', display: "Nutzername:", type: 'text'},
+      { id: 'password', display: "Passwort:", type: 'password'},
     ]
   },
   'wiso-net.de': {
@@ -30,9 +34,13 @@ export default {
     login: [
       { message: 'WISO-Konto wird eingeloggt...' },
       { click: '#customLoginLink' },
-      { fill: { selector: 'input[name="loginBlock.username"]', key: 'username' } },
-      { fill: { selector: 'input[name="loginBlock.password"]', key: 'password' } },
+      { fill: { selector: 'input[name="loginBlock.username"]', providerKey: 'wiso-net.de.options.username' } },
+      { fill: { selector: 'input[name="loginBlock.password"]', providerKey: 'wiso-net.de.options.password' } },
       { click: '#loginBlock_c1' }
+    ],
+    options: [
+      { id: 'username', display: "Nutzername:", type: 'text'},
+      { id: 'password', display: "Passwort:", type: 'password'},
     ]
   }
 }

--- a/src/providers.js
+++ b/src/providers.js
@@ -42,5 +42,26 @@ export default {
       { id: 'username', display: "Nutzername:", type: 'text'},
       { id: 'password', display: "Passwort:", type: 'password'},
     ]
+  },
+  'sso.wiso-net.de': {
+    name: 'WISO – Die Datenbank für Hochschulen (SSO)',
+    web: 'https://www.wiso-net.de/',
+    params: {
+      'genios.de': {
+        domain: 'www.wiso-net.de'
+      }
+    },
+    login: [
+      { message: 'WISO-Konto wird eingeloggt (SSO)...' },
+      { fill: { selector: '#shibbolethForm_selectedCity', providerKey: 'sso.wiso-net.de.options.city' } },
+      { event: { selector:'#shibbolethForm_selectedCity', event: 'change' } },
+      { wait: 2000 },
+      { fill: { selector: '#shibbolethForm_selectedName', providerKey: 'sso.wiso-net.de.options.name'} },
+      { click: '#shibbolethForm_shLoginLink'}
+    ],
+    options: [
+      { id: 'city', display: 'Stadt der Hochschule/Uni:', type: 'text'},
+      { id: 'name', display: 'Name der Hochschule/Uni:', type: 'text'}
+    ]
   }
 }

--- a/src/reader.js
+++ b/src/reader.js
@@ -6,10 +6,9 @@ const storageItems = {}
 
 function retrieveStorage () {
   const defaults = {
-    username: '',
-    password: '',
     keepStats: true,
-    provider: DEFAULT_PROVIDER
+    provider: DEFAULT_PROVIDER,
+    providerOptions: {}
   }
   return browser.storage.sync.get(defaults).then(function (items) {
     for (const key in items) {

--- a/src/sources.js
+++ b/src/sources.js
@@ -23,7 +23,7 @@ export default {
     ]
   },
   'genios.de': {
-    loggedIn: ".boxLogin a[href='/openIdConnectClient/logout']",
+    loggedIn: ".boxLogin a[href='/openIdConnectClient/logout'], .moduleLogoPersonal",
     start: 'https://{source.domain}/',
     defaultParams: {
       domain: 'www.genios.de'

--- a/src/tabrunner.js
+++ b/src/tabrunner.js
@@ -40,6 +40,8 @@ class TabRunner {
     if (action.fill) {
       if (this.userData[action.fill.key]) {
         return [`document.querySelector('${action.fill.selector}').value = '${this.userData[action.fill.key]}'`]
+      } else if (action.fill.providerKey) {
+        return [`document.querySelector('${action.fill.selector}').value = '${this.userData.providerOptions[action.fill.providerKey]}'`]
       } else {
         return []
       }

--- a/src/tabrunner.js
+++ b/src/tabrunner.js
@@ -45,6 +45,12 @@ class TabRunner {
       } else {
         return []
       }
+    } else if (action.event) {
+      return [`document.querySelector('${action.event.selector}').dispatchEvent(new Event('${action.event.event}'))`]
+    } else if (action.wait) {
+      var start = new Date().getTime(), expire = start + action.wait;
+      while (new Date().getTime() < expire) { }
+      return [];
     } else if (action.failOnMissing) {
       return [
         `document.querySelector('${action.failOnMissing}') !== null`,

--- a/src/update.js
+++ b/src/update.js
@@ -1,0 +1,33 @@
+export default {
+    run_update: function (previousVersion, currentVersion) {
+        if (previousVersion <= "0.11.0") {
+            // Storage of user options now is provider dependent
+            // Move the options for VOEBB to provider specific storage
+            console.log("Update from < 0.12.0 - Changing from user options to provider dependent user options")
+
+            const defaults = {
+                username: null,
+                password: null
+            }
+
+            browser.storage.sync.get(defaults).then((items) => {
+                if (items.username && items.password) {
+                    console.log("Found credentials:", items.username, items.password)
+
+                    const newStorage = {
+                        providerOptions: {}
+                    }
+
+                    newStorage.providerOptions['voebb.de.options.username'] = items.username
+                    newStorage.providerOptions['voebb.de.options.password'] = items.password
+                    browser.storage.sync.set(newStorage)
+                        .catch((e) => console.log("Failes to save new entries to storage:", e))
+                    browser.storage.sync.remove(['username', 'password'])
+                        .catch((e) => console.log("Failed to remove old entries:", e))
+                } else {
+                    console.log("There isn't any username or any password set, skipping")
+                }
+            }, (e) => console.log("Failed to fetch old credentials:", e))
+        }
+    }
+}

--- a/src/update.js
+++ b/src/update.js
@@ -12,7 +12,7 @@ export default {
 
             browser.storage.sync.get(defaults).then((items) => {
                 if (items.username && items.password) {
-                    console.log("Found credentials:", items.username, items.password)
+                    console.log("Found credentials")
 
                     const newStorage = {
                         providerOptions: {}


### PR DESCRIPTION
Moved the user options into provider specific fields so you can store different credentials for different providers. This allows to store the configuration for the WISO SSO provider, which needs a city an the name of the university.

WISO redirects you to your SSO page, so if you aren't logged in in regards to your SSO provider, then you have to sign in manually and reload the article to retrigger the voebbot.

Fixes #12 