### PR TITLE
Fix sueddeutsche.de teaser extraction

### DIFF
--- a/src/sites.js
+++ b/src/sites.js
@@ -81,7 +81,7 @@ export default {
     selectors: {
       // query: "article > header > h2 > span:last-child",
       query: () => {
-        return extractQuery(document.querySelector('.sz-article-body__paragraph'))
+        return extractQuery(document.querySelector("[class^='sz-article-body__paragraph']"))
       },
       date: 'time',
       paywall: 'offer-page',
@@ -89,7 +89,7 @@ export default {
       mimic: '.sz-article-body__paragraph'
     },
     start: (root) => {
-      const p = root.querySelector('.sz-article-body__paragraph--reduced')
+      const p = root.querySelector("[class^='sz-article-body__paragraph']")
       if (p) {
         p.className = 'sz-article-body__paragraph'
       }


### PR DESCRIPTION
Now with your recent fixes my library works as well - amazing. Thanks so much for your work :)

Fix teaser / query extraction for https://www.sueddeutsche.de/panorama/suezkanal-schiff-ever-given-aegypten-1.5250793?reduced=true

The initial `return extractQuery(document.querySelector('.sz-article-body__paragraph'))` was too strict to extract `.sz-article-body__paragraph--reduced`. I am not sure of the semantics of "mimic" and that you manually set the className in start() - so maybe you want to solve this differently.