### PR TITLE
add maz-online.de

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,7 +43,8 @@
         "https://www.moz.de/*",
         "https://www.noz.de/*",
         "https://www.waz.de/*",
-        "https://www.heise.de/*"
+        "https://www.heise.de/*",
+        "https://www.maz-online.de/*"
       ],
       "js": [
         "lib/browser-polyfill.js",

--- a/src/sites.js
+++ b/src/sites.js
@@ -161,6 +161,20 @@ export default {
       dbShortcut: 'MOZ'
     }
   },
+  'www.maz-online.de': {
+    selectors: {
+      query: '.pdb-article-teaser-breadcrumb-headline-title',
+      paywall: '.pdb-article-paidcontent-registration',
+      main: '.pdb-article-body'
+    },
+    start: (root) => {
+      root.querySelector('.pdb-article-paidcontent-registration').remove()
+    },
+    source: 'genios.de',
+    sourceParams: {
+      dbShortcut: 'MAER'
+    }
+  },
   'www.nordkurier.de': {
     selectors: {
       query: 'article h1',


### PR DESCRIPTION
https://www.maz-online.de/Lokales/Potsdam/Prinz-Philip-hat-in-Potsdam-Bier-getrunken-Chef-der-Meierei-trauert-um-den-verstorbenen-Ehemann-der-Queen correctly resolves to Dokumentnummer "doc7fa9czq1c80k6jop5lq"