### PR TITLE
Support libraries using OCLC, fix Stadtbibliothek Hannover

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,8 @@
   "optional_permissions": [
     "https://www.munzinger.de/*",
     "https://www.voebb.de/*",
-    "https://www.wiso-net.de/*"
+    "https://www.wiso-net.de/*",
+    "https://*.stbhannover.idm.oclc.org/*"
   ],
   "background": {
     "scripts": [

--- a/src/providers.js
+++ b/src/providers.js
@@ -54,12 +54,6 @@ const geniosDefaultData = [
     domain: 'bib-halle.genios.de'
   },
   {
-    id: 'bibliothek.hannover-stadt.de',
-    name: 'Stadtbibliothek Hannover',
-    web: 'https://bibliothek.hannover-stadt.de',
-    domain: 'bib-hannover.genios.de'
-  },
-  {
     id: 'stadtbibliothek.heilbronn.de',
     name: 'Stadtbibliothek Heilbronn',
     web: 'https://stadtbibliothek.heilbronn.de/stadtbibliothek-heilbronn.html',
@@ -301,6 +295,16 @@ const geniosAssociationData = [
   }
 ]
 
+const geniosOclcData = [
+  {
+    id: 'bibliothek.hannover-stadt.de',
+    name: 'Stadtbibliothek Hannover',
+    web: 'https://bibliothek.hannover-stadt.de',
+    oclcId: 'stbhannover',
+    geniosDomain: 'bib-hannover-genios-de'
+  }
+]
+
 function geniosFactory (provider) {
   return {
     name: provider.name,
@@ -347,6 +351,31 @@ function geniosAssociationFactory (provider) {
   }
 }
 
+function geniosOclcFactory (provider) {
+  return {
+    name: provider.name,
+    web: provider.web,
+    loginHint: '',
+    params: {
+      'genios.de': {
+        domain: `${provider.geniosDomain}.${provider.oclcId}.idm.oclc.org`
+      }
+    },
+    login: [
+      [
+        { fill: { selector: 'input[name="user"]', providerKey: provider.id + '.options.username' } },
+        { fill: { selector: 'input[name="pass"]', providerKey: provider.id + '.options.password' } },
+        { click: 'input[type="submit"]' }
+      ]
+    ],
+    options: [
+      { id: 'username', display: 'Nutzername:', type: 'text' },
+      { id: 'password', display: 'Passwort:', type: 'password' }
+    ],
+    permissions: [`https://*.${provider.oclcId}.idm.oclc.org/*`]
+  }
+}
+
 const geniosDefaultProviders = {}
 geniosDefaultData.forEach(d => {
   geniosDefaultProviders[d.id] = geniosFactory(d)
@@ -357,9 +386,15 @@ geniosAssociationData.forEach(d => {
   geniosDefaultProviders[d.id] = geniosAssociationFactory(d)
 })
 
+const geniosOclcProviders = {}
+geniosOclcData.forEach(d => {
+  geniosOclcProviders[d.id] = geniosOclcFactory(d)
+})
+
 export default {
   ...geniosDefaultProviders,
   ...geniosAssociationProviders,
+  ...geniosOclcProviders,
   'voebb.de': {
     name: 'VÖBB - Verbund der öffenlichen Bibliotheken Berlins',
     web: 'https://voebb.de/',

--- a/src/providers.js
+++ b/src/providers.js
@@ -295,13 +295,19 @@ const geniosAssociationData = [
   }
 ]
 
-const geniosOclcData = [
+const oclcData = [
   {
     id: 'bibliothek.hannover-stadt.de',
     name: 'Stadtbibliothek Hannover',
     web: 'https://bibliothek.hannover-stadt.de',
     oclcId: 'stbhannover',
-    geniosDomain: 'bib-hannover-genios-de'
+    'genios.de': {
+      subdomain: 'bib-hannover-genios-de'
+    },
+    'www.munzinger.de': {
+      subdomain: 'www-munzinger-de',
+      portalId: 51488 // not used in original requests, obtained from logo: https://www.munzinger.de/logos/51488.gif
+    }
   }
 ]
 
@@ -351,14 +357,26 @@ function geniosAssociationFactory (provider) {
   }
 }
 
-function geniosOclcFactory (provider) {
+function oclcFactory (provider) {
   return {
     name: provider.name,
     web: provider.web,
     loginHint: '',
     params: {
-      'genios.de': {
-        domain: `${provider.geniosDomain}.${provider.oclcId}.idm.oclc.org`
+      ...(provider['genios.de']) && {
+        'genios.de': {
+          domain: `${provider['genios.de'].subdomain}.${provider.oclcId}.idm.oclc.org`
+        }
+      },
+      ...(provider['www.munzinger.de']) && {
+        'www.munzinger.de': {
+          ...(provider['www.munzinger.de'].portalId) && {
+            portalId: provider['www.munzinger.de'].portalId
+          },
+          ...(provider['www.munzinger.de'].subdomain) && {
+            domain: `${provider['www.munzinger.de'].subdomain}.${provider.oclcId}.idm.oclc.org`
+          }
+        }
       }
     },
     login: [
@@ -386,15 +404,15 @@ geniosAssociationData.forEach(d => {
   geniosDefaultProviders[d.id] = geniosAssociationFactory(d)
 })
 
-const geniosOclcProviders = {}
-geniosOclcData.forEach(d => {
-  geniosOclcProviders[d.id] = geniosOclcFactory(d)
+const oclcProviders = {}
+oclcData.forEach(d => {
+  oclcProviders[d.id] = oclcFactory(d)
 })
 
 export default {
   ...geniosDefaultProviders,
   ...geniosAssociationProviders,
-  ...geniosOclcProviders,
+  ...oclcProviders,
   'voebb.de': {
     name: 'VÖBB - Verbund der öffenlichen Bibliotheken Berlins',
     web: 'https://voebb.de/',

--- a/src/sources.js
+++ b/src/sources.js
@@ -1,7 +1,13 @@
 export default {
   'www.munzinger.de': {
     loggedIn: ".metanav-a[href='/search/logout']",
-    start: 'https://www.munzinger.de/search/go/spiegel/aktuell.jsp?portalid={source.portalId}',
+    start: 'https://{source.domain}/search/go/spiegel/aktuell.jsp?portalid={source.portalId}',
+    defaultParams: {
+      domain: 'www.munzinger.de',
+      // reverse-proxied portals such as www-munzinger-de.stbhannover.idm.oclc.org may not use portalId,
+      // adding an empty ?portalid= parameter works in these cases
+      portalId: ''
+    },
     login: [
       [
         { click: '.gdprcookie-buttons button', optional: true },
@@ -13,7 +19,7 @@ export default {
     search: [
       [
         { message: 'Suche wird durchgeführt...' },
-        { url: 'https://www.munzinger.de/search/query?template=%2Fpublikationen%2Fspiegel%2Fresult.jsp&query.id=query-spiegel&query.key=gQynwrIS&query.commit=yes&query.scope=spiegel&query.index-order=personen&query.facets=yes&facet.path=%2Fspiegel&facet.activate=yes&hitlist.highlight=yes&hitlist.sort=-field%3Aisort&query.Titel={query}&query.Ausgabe={edition}&query.Ressort=&query.Signatur=&query.Person=&query.K%C3%B6rperschaft=&query.Ort=&query.Text={overline}' }
+        { url: 'https://{source.domain}/search/query?template=%2Fpublikationen%2Fspiegel%2Fresult.jsp&query.id=query-spiegel&query.key=gQynwrIS&query.commit=yes&query.scope=spiegel&query.index-order=personen&query.facets=yes&facet.path=%2Fspiegel&facet.activate=yes&hitlist.highlight=yes&hitlist.sort=-field%3Aisort&query.Titel={query}&query.Ausgabe={edition}&query.Ressort=&query.Signatur=&query.Person=&query.K%C3%B6rperschaft=&query.Ort=&query.Text={overline}' }
       ],
       [
         { click: '.gdprcookie-buttons button', optional: true },


### PR DESCRIPTION
STB Hannover uses [OCLC's](https://www.oclc.org) single-sign-on and reverse proxy solution to provide remote access to Genios and Munzinger.

This PR adds support for accessing Munzinger via library-specific domains and fixes STB Hannover Genios requests.

(Querying Munzinger is currently broken for other reasons, this PR does not address that as no sources use it for now.)

Happy holidays! 🎄