### PR TITLE
Unterstützung für Bibliotheken, die HAN zum Zugriff auf Zeitschriften nutzen

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,8 @@
     "https://www.munzinger.de/*",
     "https://www.voebb.de/*",
     "https://www.wiso-net.de/*",
-    "https://*.stbhannover.idm.oclc.org/*"
+    "https://*.stbhannover.idm.oclc.org/*",
+    "https://*.han.landesbibliothek.at/*"
   ],
   "background": {
     "scripts": [

--- a/src/providers.js
+++ b/src/providers.js
@@ -311,6 +311,19 @@ const oclcData = [
   }
 ]
 
+const hanData = [
+  {
+    id: 'landesbibliothek.at',
+    name: 'OÖ Landesbibliothek',
+    web: 'https://www.landesbibliothek.at',
+    hanserver: 'han.landesbibliothek.at',
+    'genios.de': {
+      hanid: 'wisonet',
+      domain: 'www.wiso-net.de'
+    }
+  }
+]
+
 function geniosFactory (provider) {
   return {
     name: provider.name,
@@ -394,6 +407,33 @@ function oclcFactory (provider) {
   }
 }
 
+function hanFactory (provider) {
+  return {
+    name: provider.name,
+    web: provider.web,
+    loginHint: '',
+    params: {
+      ...(provider['genios.de']) && {
+        'genios.de': {
+          domain: `${provider.hanserver}/han/${provider['genios.de'].hanid}/${provider['genios.de'].domain}`
+        }
+      }
+    },
+    login: [
+      [
+        { fill: { selector: 'input[name="plainuser"]', providerKey: provider.id + '.options.username' } },
+        { fill: { selector: 'input[name="password"]', providerKey: provider.id + '.options.password' } },
+        { click: 'button[type="submit"]' }
+      ]
+    ],
+    options: [
+      { id: 'username', display: 'Nutzername:', type: 'text' },
+      { id: 'password', display: 'Passwort:', type: 'password' }
+    ],
+    permissions: [`https://*.${provider.hanserver}/*`]
+  }
+}
+
 const geniosDefaultProviders = {}
 geniosDefaultData.forEach(d => {
   geniosDefaultProviders[d.id] = geniosFactory(d)
@@ -409,10 +449,16 @@ oclcData.forEach(d => {
   oclcProviders[d.id] = oclcFactory(d)
 })
 
+const hanProviders = {}
+hanData.forEach(d => {
+  hanProviders[d.id] = hanFactory(d)
+})
+
 export default {
   ...geniosDefaultProviders,
   ...geniosAssociationProviders,
   ...oclcProviders,
+  ...hanProviders,
   'voebb.de': {
     name: 'VÖBB - Verbund der öffenlichen Bibliotheken Berlins',
     web: 'https://voebb.de/',

--- a/src/sources.js
+++ b/src/sources.js
@@ -1,7 +1,7 @@
 export default {
   'www.munzinger.de': {
     loggedIn: ".metanav-a[href='/search/logout']",
-    start: 'https://{source.domain}/search/go/spiegel/aktuell.jsp?portalid={source.portalId}',
+    start: 'https://{source.domain.raw}/search/go/spiegel/aktuell.jsp?portalid={source.portalId}',
     defaultParams: {
       domain: 'www.munzinger.de',
       // reverse-proxied portals such as www-munzinger-de.stbhannover.idm.oclc.org may not use portalId,
@@ -19,7 +19,7 @@ export default {
     search: [
       [
         { message: 'Suche wird durchgeführt...' },
-        { url: 'https://{source.domain}/search/query?template=%2Fpublikationen%2Fspiegel%2Fresult.jsp&query.id=query-spiegel&query.key=gQynwrIS&query.commit=yes&query.scope=spiegel&query.index-order=personen&query.facets=yes&facet.path=%2Fspiegel&facet.activate=yes&hitlist.highlight=yes&hitlist.sort=-field%3Aisort&query.Titel={query}&query.Ausgabe={edition}&query.Ressort=&query.Signatur=&query.Person=&query.K%C3%B6rperschaft=&query.Ort=&query.Text={overline}' }
+        { url: 'https://{source.domain.raw}/search/query?template=%2Fpublikationen%2Fspiegel%2Fresult.jsp&query.id=query-spiegel&query.key=gQynwrIS&query.commit=yes&query.scope=spiegel&query.index-order=personen&query.facets=yes&facet.path=%2Fspiegel&facet.activate=yes&hitlist.highlight=yes&hitlist.sort=-field%3Aisort&query.Titel={query}&query.Ausgabe={edition}&query.Ressort=&query.Signatur=&query.Person=&query.K%C3%B6rperschaft=&query.Ort=&query.Text={overline}' }
       ],
       [
         { click: '.gdprcookie-buttons button', optional: true },
@@ -29,7 +29,7 @@ export default {
   },
   'genios.de': {
     loggedIn: '.boxMyGeniosLink',
-    start: 'https://{source.domain}/',
+    start: 'https://{source.domain.raw}/',
     defaultParams: {
       domain: 'www.genios.de'
     },
@@ -45,7 +45,7 @@ export default {
     search: [
       [
         { message: 'Suche wird durchgeführt...' },
-        { url: 'https://{source.domain}/dosearch?explicitSearch=true&q={query}&dbShortcut={source.dbShortcut}&TI%2CUT%2CDZ%2CBT%2COT%2CSL=&AU=&KO=&MM%2COW%2CUF%2CMF%2CAO%2CTP%2CVM%2CNN%2CNJ%2CKV%2CZ2=&CT%2CDE%2CZ4%2CKW=&Z3%2CCN%2CCE%2CKC%2CTC%2CVC=&DT_from=&DT_to=&timeFilterType=selected&timeFilter=NONE&x=59&y=11' }
+        { url: 'https://{source.domain.raw}/dosearch?explicitSearch=true&q={query}&dbShortcut={source.dbShortcut}&TI%2CUT%2CDZ%2CBT%2COT%2CSL=&AU=&KO=&MM%2COW%2CUF%2CMF%2CAO%2CTP%2CVM%2CNN%2CNJ%2CKV%2CZ2=&CT%2CDE%2CZ4%2CKW=&Z3%2CCN%2CCE%2CKC%2CTC%2CVC=&DT_from=&DT_to=&timeFilterType=selected&timeFilter=NONE&x=59&y=11' }
       ],
       [
         { message: 'Artikel wird aufgerufen...' },

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,12 +2,16 @@ const ident = (x) => x
 
 function interpolate (str, params, prefix = '', converter = ident, fallback = '') {
   if (prefix.length > 0) {
-    prefix = `${prefix}.`
+    prefix = `${prefix}\\.`
   }
   for (const key in params) {
     str = str.replace(
       new RegExp(`{${prefix}${key}}`),
       converter(params[key] || fallback)
+    )
+    str = str.replace(
+      new RegExp(`{${prefix}${key}\\.raw}`),
+      params[key] || fallback
     )
   }
   return str


### PR DESCRIPTION
Viele Universitäten und Bildungsinstitutionen lizenzieren den Zugriff auf digitale Zeitschriften über die IP-Adresse der Bibliothek und nicht anhand einzelner Benutzerkonten. Dadurch kann innerhalb der Bibliothek direkt recherchiert werden und man benötigt keine Zugangsdaten. Um für die Bibliotheksbenutzer auch einen Zugriff von außerhalb der Bibliothek zu ermöglichen, wird gerne HAN ([Hidden Automatic Navigator](https://www.hh-han.com/)) benutzt. Die Software hängt sich als Proxy zwischen Benutzer und Zielseite und man muss sich nur einmalig pro Sitzung am Proxy anmelden.

Dieser Pull Request fügt Unterstützung für Bibliotheken hinzu, die HAN verwenden. Dafür muss jede Bibliothek mit HAN händisch in die Liste der unterstützten Bibliotheken hinzugefügt werden. Theoretisch könnte man wie beim SSO die HAN-Serveradresse und die Ressourcen-ID durch den Benutzer beliebig konfigurierbar machen, allerdings müsste man dann die optionalen Berechtigungen des Add-ons auf jegliche Server erweitern.