### PR TITLE
Add second possible selector to retrieving text from Genios

### DIFF
--- a/src/sources.js
+++ b/src/sources.js
@@ -54,7 +54,7 @@ export default {
       ],
       [
         { captcha: '#layer_captcha' },
-        { extract: '.divDocument pre.text', convert: 'preToParagraph' }
+        { extract: '.divDocument pre.text, .divDocument pre.textCompact', convert: 'preToParagraph' }
       ]
     ]
   }


### PR DESCRIPTION
Manche Presseartikel haben bei Genios offenbar nicht die CSS-Klasse `text`, sondern `textCompact` gesetzt. Der Extraktor beachtet so beide Varianten.

Beispiel: https://www.genios.de/document/PRE__PRESSE_20220225_DC5C44942D/toc?all=