### PR TITLE
manager-magazin.de - fix line-breaks

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -185,6 +185,9 @@ const sites: Sites = {
     sourceParams: {
       dbShortcut: 'MM,MMAG',
     },
+    mimic: (content) => {
+     return content.replace(/<p>/g, '<p style="margin-block: revert !important;">')
+    },
   },
   'www.tagesspiegel.de': {
     examples: [


### PR DESCRIPTION
this fixes missing line breaks between paragraphs for `www.manager-magazin.de` (`mm` / `mmag`).

**before this change:**

![Screenshot_20250704_213517](https://github.com/user-attachments/assets/5bead44e-80e5-472c-bcc3-529866d3506f)


**with this change:**

![Screenshot_20250704_213257](https://github.com/user-attachments/assets/0a94e37d-a55e-46ca-8519-161d103187b9)




