### PR TITLE
Support für die Stadtbibliothek Frankfurt / bibliotheken-hessen.de (Genios)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,8 +18,7 @@
     "scripting"
   ],
   "host_permissions": [
-    "https://*.genios.de/*",
-    "https://auth.bibliotheken-hessen.de/*"
+    "https://*.genios.de/*"
   ],
   "optional_host_permissions": [
     "https://www.munzinger.de/*",
@@ -41,7 +40,8 @@
     "https://*.bonn.idm.oclc.org/*",
     "https://online-service2.nuernberg.de/*",
     "https://*.webopac.wuppertal.de:1443/*",
-    "https://ssl.muenchen.de/*"
+    "https://ssl.muenchen.de/*",
+    "https://auth.bibliotheken-hessen.de/*"
   ],
   "background": {
     "service_worker": "build/background.js",

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,8 @@
     "scripting"
   ],
   "host_permissions": [
-    "https://*.genios.de/*"
+    "https://*.genios.de/*",
+    "https://auth.bibliotheken-hessen.de/*"
   ],
   "optional_host_permissions": [
     "https://www.munzinger.de/*",

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -461,6 +461,65 @@ const oclcData = [
   },
 ]
 
+type GeniosHessenType = {
+  id: string;
+  name: string;
+  web: string;
+  domain: string;
+  bibName: string; // Name im Login Auswahlmenü von https://auth.bibliotheken-hessen.de/
+}
+
+
+const geniosHessenData: GeniosHessenType[] = [{
+  id: 'stadtbuecherei.frankfurt.de',
+  name: 'Stadtbücherei Frankfurt',
+  web: 'https://stadtbuecherei.frankfurt.de',
+  domain: 'bib-hessen.genios.de',
+  bibName: 'Frankfurt am Main' // wird für das Matching im Login-Menü verwendet
+}, 
+
+// rudimentärer Support für die anderen Bibs aus Hessen
+...(["Bad Nauheim (Stadtbücherei Bad Nauheim)",
+  "Bad Soden am Taunus (Stadtbücherei Bad Soden)",
+  "Bad Vilbel (Stadtbibliothek Bad Vilbel)",
+  "Bruchköbel (Stadtbibliothek Bruchköbel)",
+  "Büdingen (Stadtbücherei Büdingen)",
+  "Darmstadt (Campus Marienhöhe gGmbH/Schulmediothek Darmstadt)",
+  "Erbach (Kath. öffentliche Bücherei St. Sophia Erbach)",
+  "Fulda (Hochschul-, Landes- und Stadtbibliothek Fulda)",
+  "Geisenheim (Stadtbücherei Geisenheim)",
+  "Gelnhausen (Grimmelshausen-Bibliothek Gelnhausen)",
+  "Hanau (Stadtbibliothek Hanau)",
+  "Herborn (Stadtbücherei Herborn)",
+  "Heusenstamm (Stadtbücherei Heusenstamm)",
+  "Hofheim (Stadtbücherei Hofheim)",
+  "Idstein (Stadtbücherei Idstein)",
+  "Kassel (Stadtbibliothek Kassel)",
+  "Kelkheim (Stadtbücherei Kelkheim)",
+  "Kelsterbach (Stadt- und Schulbibliothek Kelsterbach)",
+  "Korbach (Stadtbücherei Korbach)",
+  "Kriftel (Gemeindebücherei Kriftel)",
+  "Kronberg im Taunus (Stadtbücherei Kronberg)",
+  "Lauterbach (Stadtbücherei Lauterbach)",
+  "Mühlheim am Main (Stadtbücherei Mühlheim)",
+  "Neu-Isenburg (Stadtbibliothek Neu-Isenburg)",
+  "Nidda (Stadtbibliothek Nidda)",
+  "Oberursel (Stadtbücherei Oberursel)",
+  "Offenbach am Main (Stadtbibliothek Offenbach)",
+  "Rheingau-Taunus-Kreis (Bad Schwalbach) (Rheingau-Taunus-Kreis)",
+  "Rodgau (Stadtbücherei Rodgau)",
+  "Schlitz (Stadtbücherei Schlitz)",
+  "Taunusstein (Stadtbücherei Taunusstein)",
+  "Wetzlar (IMeNS-Zentrale)",
+  "Wiesbaden (Hochschul-und Landesbibliothek RheinMain, Wiesbaden)"].map((d, i) => ({
+    id: `hessenGenios-${i}`,
+    name: d,
+    web: '',
+    domain: 'bib-hessen.genios.de',
+    bibName: d
+  })))
+]
+
 const hanData = [
   {
     id: 'landesbibliothek.at',
@@ -497,12 +556,60 @@ function geniosFactory(provider) {
 }
 
 const selectDropDown = (userData) => {
-  ;(Array.from(document.querySelectorAll('.dropdown__option')) as HTMLElement[])
+  ; (Array.from(document.querySelectorAll('.dropdown__option')) as HTMLElement[])
     .filter((el) => el.innerText.includes(userData.bibName))[0]
     .click()
 }
 
-function geniosAssociationFactory(provider) {
+
+function geniosHessenFactory(provider: GeniosHessenType) {
+  const login: Actions[] = [
+    [
+      {
+        fill: {
+          selector: 'input[name="ausweisnummer"]',
+          providerKey: provider.id + '.options.username',
+        },
+      },
+      {
+        fill: {
+          selector: 'input[name="password"]',
+          providerKey: provider.id + '.options.password',
+        },
+      },
+      {
+        func: (userData: GeniosHessenType) => {
+          const value = Array.from(document.querySelectorAll('option')).find(d => d.innerText.includes(userData.bibName)).value;
+          (document.querySelector('#bibliothek') as HTMLInputElement).value = value;
+          return true;
+        }
+      },
+      { click: 'input[name="terms"]' },
+      { click: 'input[name="privacy"]' },
+      { func: () => document.querySelector('form').submit() },
+    ],
+  ];
+
+
+  return {
+    id: provider.id,
+    name: provider.name,
+    web: provider.web,
+    defaultSource: 'genios.de',
+    params: {
+      'genios.de': {
+        domain: provider.domain,
+      },
+    },
+    login,
+    options: [
+      { id: 'username', display: 'Nutzername:', type: 'text' },
+      { id: 'password', display: 'Passwort:', type: 'password' },
+    ],
+  }
+}
+
+function geniosAssociationFactory(provider): DefaultProvider {
   let login: Actions[] = [
     [
       { click: '.ccm--decline-cookies', optional: true },
@@ -759,6 +866,7 @@ const providers: Providers = {
   ...oclcProviders,
   ...hanProviders,
   ...astecProviders,
+  ...Object.fromEntries(geniosHessenData.map(geniosHessenFactory).map(h => [h.id, h])),
   'www.duesseldorf.de': {
     name: 'Stadtbibliothek Düsseldorf',
     web: 'https://www.duesseldorf.de/stadtbuechereien/onlinebibliothek.html',

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -462,62 +462,64 @@ const oclcData = [
 ]
 
 type GeniosHessenType = {
-  id: string;
-  name: string;
-  web: string;
-  domain: string;
-  bibName: string; // Name im Login Auswahlmenü von https://auth.bibliotheken-hessen.de/
+  id: string
+  name: string
+  web: string
+  domain: string
+  bibName: string // Name im Login Auswahlmenü von https://auth.bibliotheken-hessen.de/
 }
 
+const geniosHessenData: GeniosHessenType[] = [
+  {
+    id: 'stadtbuecherei.frankfurt.de',
+    name: 'Stadtbücherei Frankfurt',
+    web: 'https://stadtbuecherei.frankfurt.de',
+    domain: 'bib-hessen.genios.de',
+    bibName: 'Frankfurt am Main', // wird für das Matching im Login-Menü verwendet
+  },
 
-const geniosHessenData: GeniosHessenType[] = [{
-  id: 'stadtbuecherei.frankfurt.de',
-  name: 'Stadtbücherei Frankfurt',
-  web: 'https://stadtbuecherei.frankfurt.de',
-  domain: 'bib-hessen.genios.de',
-  bibName: 'Frankfurt am Main' // wird für das Matching im Login-Menü verwendet
-}, 
-
-// rudimentärer Support für die anderen Bibs aus Hessen
-...(["Bad Nauheim (Stadtbücherei Bad Nauheim)",
-  "Bad Soden am Taunus (Stadtbücherei Bad Soden)",
-  "Bad Vilbel (Stadtbibliothek Bad Vilbel)",
-  "Bruchköbel (Stadtbibliothek Bruchköbel)",
-  "Büdingen (Stadtbücherei Büdingen)",
-  "Darmstadt (Campus Marienhöhe gGmbH/Schulmediothek Darmstadt)",
-  "Erbach (Kath. öffentliche Bücherei St. Sophia Erbach)",
-  "Fulda (Hochschul-, Landes- und Stadtbibliothek Fulda)",
-  "Geisenheim (Stadtbücherei Geisenheim)",
-  "Gelnhausen (Grimmelshausen-Bibliothek Gelnhausen)",
-  "Hanau (Stadtbibliothek Hanau)",
-  "Herborn (Stadtbücherei Herborn)",
-  "Heusenstamm (Stadtbücherei Heusenstamm)",
-  "Hofheim (Stadtbücherei Hofheim)",
-  "Idstein (Stadtbücherei Idstein)",
-  "Kassel (Stadtbibliothek Kassel)",
-  "Kelkheim (Stadtbücherei Kelkheim)",
-  "Kelsterbach (Stadt- und Schulbibliothek Kelsterbach)",
-  "Korbach (Stadtbücherei Korbach)",
-  "Kriftel (Gemeindebücherei Kriftel)",
-  "Kronberg im Taunus (Stadtbücherei Kronberg)",
-  "Lauterbach (Stadtbücherei Lauterbach)",
-  "Mühlheim am Main (Stadtbücherei Mühlheim)",
-  "Neu-Isenburg (Stadtbibliothek Neu-Isenburg)",
-  "Nidda (Stadtbibliothek Nidda)",
-  "Oberursel (Stadtbücherei Oberursel)",
-  "Offenbach am Main (Stadtbibliothek Offenbach)",
-  "Rheingau-Taunus-Kreis (Bad Schwalbach) (Rheingau-Taunus-Kreis)",
-  "Rodgau (Stadtbücherei Rodgau)",
-  "Schlitz (Stadtbücherei Schlitz)",
-  "Taunusstein (Stadtbücherei Taunusstein)",
-  "Wetzlar (IMeNS-Zentrale)",
-  "Wiesbaden (Hochschul-und Landesbibliothek RheinMain, Wiesbaden)"].map((d, i) => ({
+  // rudimentärer Support für die anderen Bibs aus Hessen
+  ...[
+    'Bad Nauheim (Stadtbücherei Bad Nauheim)',
+    'Bad Soden am Taunus (Stadtbücherei Bad Soden)',
+    'Bad Vilbel (Stadtbibliothek Bad Vilbel)',
+    'Bruchköbel (Stadtbibliothek Bruchköbel)',
+    'Büdingen (Stadtbücherei Büdingen)',
+    'Darmstadt (Campus Marienhöhe gGmbH/Schulmediothek Darmstadt)',
+    'Erbach (Kath. öffentliche Bücherei St. Sophia Erbach)',
+    'Fulda (Hochschul-, Landes- und Stadtbibliothek Fulda)',
+    'Geisenheim (Stadtbücherei Geisenheim)',
+    'Gelnhausen (Grimmelshausen-Bibliothek Gelnhausen)',
+    'Hanau (Stadtbibliothek Hanau)',
+    'Herborn (Stadtbücherei Herborn)',
+    'Heusenstamm (Stadtbücherei Heusenstamm)',
+    'Hofheim (Stadtbücherei Hofheim)',
+    'Idstein (Stadtbücherei Idstein)',
+    'Kassel (Stadtbibliothek Kassel)',
+    'Kelkheim (Stadtbücherei Kelkheim)',
+    'Kelsterbach (Stadt- und Schulbibliothek Kelsterbach)',
+    'Korbach (Stadtbücherei Korbach)',
+    'Kriftel (Gemeindebücherei Kriftel)',
+    'Kronberg im Taunus (Stadtbücherei Kronberg)',
+    'Lauterbach (Stadtbücherei Lauterbach)',
+    'Mühlheim am Main (Stadtbücherei Mühlheim)',
+    'Neu-Isenburg (Stadtbibliothek Neu-Isenburg)',
+    'Nidda (Stadtbibliothek Nidda)',
+    'Oberursel (Stadtbücherei Oberursel)',
+    'Offenbach am Main (Stadtbibliothek Offenbach)',
+    'Rheingau-Taunus-Kreis (Bad Schwalbach) (Rheingau-Taunus-Kreis)',
+    'Rodgau (Stadtbücherei Rodgau)',
+    'Schlitz (Stadtbücherei Schlitz)',
+    'Taunusstein (Stadtbücherei Taunusstein)',
+    'Wetzlar (IMeNS-Zentrale)',
+    'Wiesbaden (Hochschul-und Landesbibliothek RheinMain, Wiesbaden)',
+  ].map((d, i) => ({
     id: `hessenGenios-${i}`,
     name: d,
     web: '',
     domain: 'bib-hessen.genios.de',
-    bibName: d
-  })))
+    bibName: d,
+  })),
 ]
 
 const hanData = [
@@ -556,11 +558,10 @@ function geniosFactory(provider) {
 }
 
 const selectDropDown = (userData) => {
-  ; (Array.from(document.querySelectorAll('.dropdown__option')) as HTMLElement[])
+  ;(Array.from(document.querySelectorAll('.dropdown__option')) as HTMLElement[])
     .filter((el) => el.innerText.includes(userData.bibName))[0]
     .click()
 }
-
 
 function geniosHessenFactory(provider: GeniosHessenType) {
   const login: Actions[] = [
@@ -579,17 +580,19 @@ function geniosHessenFactory(provider: GeniosHessenType) {
       },
       {
         func: (userData: GeniosHessenType) => {
-          const value = Array.from(document.querySelectorAll('option')).find(d => d.innerText.includes(userData.bibName)).value;
-          (document.querySelector('#bibliothek') as HTMLInputElement).value = value;
-          return true;
-        }
+          const value = Array.from(document.querySelectorAll('option')).find(
+            (d) => d.innerText.includes(userData.bibName),
+          ).value
+          ;(document.querySelector('#bibliothek') as HTMLInputElement).value =
+            value
+          return true
+        },
       },
       { click: 'input[name="terms"]' },
       { click: 'input[name="privacy"]' },
       { func: () => document.querySelector('form').submit() },
     ],
-  ];
-
+  ]
 
   return {
     id: provider.id,
@@ -606,6 +609,7 @@ function geniosHessenFactory(provider: GeniosHessenType) {
       { id: 'username', display: 'Nutzername:', type: 'text' },
       { id: 'password', display: 'Passwort:', type: 'password' },
     ],
+    permissions: ['https://auth.bibliotheken-hessen.de/*'],
   }
 }
 
@@ -866,7 +870,9 @@ const providers: Providers = {
   ...oclcProviders,
   ...hanProviders,
   ...astecProviders,
-  ...Object.fromEntries(geniosHessenData.map(geniosHessenFactory).map(h => [h.id, h])),
+  ...Object.fromEntries(
+    geniosHessenData.map(geniosHessenFactory).map((h) => [h.id, h]),
+  ),
   'www.duesseldorf.de': {
     name: 'Stadtbibliothek Düsseldorf',
     web: 'https://www.duesseldorf.de/stadtbuechereien/onlinebibliothek.html',


### PR DESCRIPTION
Getestet für: 
- Frankfurt am Main (Stadtbücherei Frankfurt)

Ungetestet:
- Bad Nauheim (Stadtbücherei Bad Nauheim)
- Bad Soden am Taunus (Stadtbücherei Bad Soden)
- Bad Vilbel (Stadtbibliothek Bad Vilbel)
- Bruchköbel (Stadtbibliothek Bruchköbel)
- Büdingen (Stadtbücherei Büdingen)
- Darmstadt (Campus Marienhöhe gGmbH/Schulmediothek Darmstadt)
- Erbach (Kath. öffentliche Bücherei St. Sophia Erbach)
- Fulda (Hochschul-, Landes- und Stadtbibliothek Fulda)
- Geisenheim (Stadtbücherei Geisenheim)
- Gelnhausen (Grimmelshausen-Bibliothek Gelnhausen)
- Hanau (Stadtbibliothek Hanau)
- Herborn (Stadtbücherei Herborn)
- Heusenstamm (Stadtbücherei Heusenstamm)
- Hofheim (Stadtbücherei Hofheim)
- Idstein (Stadtbücherei Idstein)
- Kassel (Stadtbibliothek Kassel)
- Kelkheim (Stadtbücherei Kelkheim)
- Kelsterbach (Stadt- und Schulbibliothek Kelsterbach)
- Korbach (Stadtbücherei Korbach)
- Kriftel (Gemeindebücherei Kriftel)
- Kronberg im Taunus (Stadtbücherei Kronberg)
- Lauterbach (Stadtbücherei Lauterbach)
- Mühlheim am Main (Stadtbücherei Mühlheim)
- Neu-Isenburg (Stadtbibliothek Neu-Isenburg)
- Nidda (Stadtbibliothek Nidda)
- Oberursel (Stadtbücherei Oberursel)
- Offenbach am Main (Stadtbibliothek Offenbach)
- Rheingau-Taunus-Kreis (Bad Schwalbach) (Rheingau-Taunus-Kreis)
- Rodgau (Stadtbücherei Rodgau)
- Schlitz (Stadtbücherei Schlitz)
- Taunusstein (Stadtbücherei Taunusstein)
- Wetzlar (IMeNS-Zentrale)
- Wiesbaden (Hochschul-und Landesbibliothek RheinMain, Wiesbaden)