### PR TITLE
Fix www.aachener-zeitung.de

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -1637,15 +1637,18 @@ const sites: Sites = {
     selectors: {
       query: makeQueryFunc('article h1', false),
       date: 'article time',
-      paywall: 'div[data-testid="paywall-container"]',
+      paywall: 'div[data-testid="paywall-position-popover"]',
       main: 'main article section',
     },
     start: (root) => {
-      root.classList.remove('noscroll')
-      document.documentElement.classList.remove('noscroll')
-      const paywall: HTMLElement = root.querySelector(
-        'div[data-testid="paywall-container"]',
-      )
+      // Entferne alle Klassen, die auf "disable-scroll-popup" enden, von <body>
+      const body = document.body
+      for (const cls of Array.from(body.classList)) {
+        if (/disable-scroll-popup/i.test(cls)) {
+          body.classList.remove(cls)
+        }
+      }
+      const paywall: HTMLElement = root.querySelector('div[data-testid="paywall-position-popover"]')
       paywall.style.display = 'none'
       root
         .querySelector('main .paywalled-article')


### PR DESCRIPTION
Closes #678 

Lokal getestet. Hat für drei etwas ältere Artikel funktioniert. Die Zeitung neigt dazu Artikel in der Printausgabe ca. einen Tag später zu veröffentlichen und auf der Webseite, sodass Tagesaktuelle Nachrichten häufig leider nicht aufgelöst werden können.

Ggf. lässt sich die Paywall Popover Erkennung verbessern. z.b. Test auf attribute enthält Zeichenkette 'paywall' statt wie gerade Prüfung auf ein Attribute mit einem bestimmten Wert.