### PR TITLE
Remove article fade effect on Saarbrücker Zeitung

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -1602,6 +1602,12 @@ const sites: Sites = {
       dbShortcut: 'SAAR',
       sourceNames: ['Saarbrücker Zeitung'],
     },
+    start: () => {
+      const faidingEffectClass = 'article-content--reduced'
+      for (const faidedElement of document.getElementsByClassName(faidingEffectClass)){
+        faidedElement.classList.remove(faidingEffectClass)
+      }
+    }
   },
   'www.idowa.de': {
     selectors: {


### PR DESCRIPTION
Closes #673

Artikel ist nun vollständig lesbar.
Beim testen wurde mir unter dem Artikel die Abo Angebote der SZ angezeigt. Die sehe ich im Hauptbrowser bei mir nicht. Habe das nicht weiter untersucht. Es kann entweder daran liegen, dass ich nicht verstehe wie die Extension funktioniert, oder es liegt an den unterschiedlichen Konfigurationen und Extensions im Test Profil und in meinem normalen Hauptprofil.