### PR TITLE
fix lr-online (Lausitzer Rundschau)

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -480,10 +480,10 @@ const sites: Sites = {
   },
   'www.lr-online.de': {
     selectors: {
-      query: makeQueryFunc('.article-text .text'),
-      paywall: '#paywall-container',
-      date: 'time',
-      main: '.article-text',
+      query: makeQueryFunc('main article .u-article-header .fw-normal', false),
+      paywall: 'main article .u-paywall',
+      date: 'main article time',
+      main: 'main article > figure',
     },
     source: 'genios.de',
     sourceParams: {

--- a/src/sites.ts
+++ b/src/sites.ts
@@ -485,6 +485,7 @@ const sites: Sites = {
       date: 'main article time',
       main: 'main article > figure',
     },
+    dateRange: [4, 3],
     source: 'genios.de',
     sourceParams: {
       dbShortcut: 'LR',


### PR DESCRIPTION
Thank you for this great extension!

On [the LR article I tried to read](https://www.lr-online.de/lausitz/cottbus/re2-cottbus-berlin-trotz-sperrung-der-strecke-gibts-eine-gute-nachricht-fuer-pendler-78406681.html), copying the selectors from the (equally-structured-looking) `www.moz.de` entry made the extraction work, and extending `dateRange` into the future made this specific article work.