### PR TITLE
fix: Update selectors for title on www.shz.de

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -1526,8 +1526,8 @@ const sites: Sites = {
   },
   'www.shz.de': {
     selectors: {
-      query: makeQueryFunc('h1 span:nth-child(2)'),
-      headline: 'h1 span:nth-child(2)',
+      query: makeQueryFunc('article span.headline-icon-wrapper > span'),
+      headline: 'article span.headline-icon-wrapper > span',
       date: '.meta-box__meta',
       main: '.content--group__article section p',
       paywall: '.paywall',


### PR DESCRIPTION
Update selector for titles on SHZ.de , tested on https://www.shz.de/lokales/itzehoe/artikel/schwerer-lkw-unfall-auf-der-a23-50542125 and https://www.shz.de/deutschland-welt/panorama/artikel/buckelwal-im-livestream-helfer-wollen-tier-nahrung-anbieten-50343392 .

This should fix https://github.com/stefanw/bibbot/issues/539