### PR TITLE
Option: Bot manuell starten

### DIFF
--- a/options/options.html
+++ b/options/options.html
@@ -94,7 +94,7 @@
         <h3>Start-Verhalten</h3>
         <label>
           <input type="checkbox" id="manualTrigger">
-          Manuellen Start verwenden (Schwebe-Button anzeigen) statt automatische Suche
+          Manuellen Start verwenden (Schwebe-Button anzeigen) statt automatischer Suche
         </label>
 
         <h3>Wollen Sie wissen, ob sich ein direktes Abo bei einem Medium lohnt?</h3>

--- a/options/options.html
+++ b/options/options.html
@@ -90,6 +90,13 @@
             Hinweis: Ihr Daten (inkl. Passwort) werden im Klartext gespeichert, so dass diese automatisch ausgefüllt werden können.<br/>
           </small>
         </p>
+
+        <h3>Start-Verhalten</h3>
+        <label>
+          <input type="checkbox" id="manualTrigger">
+          Manuellen Start verwenden (Schwebe-Button anzeigen) statt automatische Suche
+        </label>
+
         <h3>Wollen Sie wissen, ob sich ein direktes Abo bei einem Medium lohnt?</h3>
         <label>
           <input type="checkbox" id="keepStats">

--- a/src/const.ts
+++ b/src/const.ts
@@ -18,4 +18,5 @@ export const storageDefaults: StorageItems = {
   providerOptions: {},
   saveArticle: null,
   disabledSites: [],
+  manualTrigger: false,
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -45,25 +45,27 @@ async function createFloatingButton(siteBot) {
 
 if (site !== undefined) {
   const siteBot = new SiteBot(site, document.body, domain)
-  ;(async () => {
-    const items = await browser.storage.sync.get({ manualTrigger: false, disabledSites: [] })
-    if (items.disabledSites && items.disabledSites.includes(domain)) {
-      return
-    }
-    if (items.manualTrigger) {
-      createFloatingButton(siteBot)
-    } else {
-      if (siteBot.site.waitOnLoad) {
-        if (document.readyState === 'complete') {
-          siteBot.start(siteBot.site.waitOnLoad)
-        } else {
-          window.addEventListener('load', () => {
-            siteBot.start(siteBot.site.waitOnLoad)
-          })
+    ; (async () => {
+      const items = await browser.storage.sync.get({ manualTrigger: false, disabledSites: [] })
+      if (items.disabledSites && items.disabledSites.includes(domain)) {
+        return
+      }
+      if (items.manualTrigger) {
+        if (siteBot.extractor.hasPaywall()) {
+          createFloatingButton(siteBot)
         }
       } else {
-        siteBot.start()
+        if (siteBot.site.waitOnLoad) {
+          if (document.readyState === 'complete') {
+            siteBot.start(siteBot.site.waitOnLoad)
+          } else {
+            window.addEventListener('load', () => {
+              siteBot.start(siteBot.site.waitOnLoad)
+            })
+          }
+        } else {
+          siteBot.start()
+        }
       }
-    }
-  })()
+    })()
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,20 +1,69 @@
+import * as browser from 'webextension-polyfill'
 import sites from './sites.js'
 import SiteBot from './sitebot.js'
+import { COLOR } from './ui.js'
 
 const domain = document.location.host
 const site = sites[domain]
 
+async function createFloatingButton(siteBot) {
+  if (document.getElementById('bibbot-float-root')) return
+  const host = document.createElement('div')
+  host.id = 'bibbot-float-root'
+  document.body.appendChild(host)
+  const shadow = host.attachShadow({ mode: 'open' })
+  const style = `
+    :host { position: fixed; top: calc(env(safe-area-inset-top, 10px) + 8px); right: calc(env(safe-area-inset-right, 10px) + 8px); z-index: 2147483647; }
+    #btn { all: initial; box-sizing: border-box; display: inline-flex; align-items: center; justify-content: center; height: 48px; width: 56px; border-radius: 24px 0 0 24px; background: ${COLOR}; color: white; border: none; cursor: pointer; box-shadow: 0 2px 8px rgba(0,0,0,.3); padding: 8px 12px; overflow: visible; }
+    #btn:active { transform: translateY(1px); }
+  `
+  shadow.innerHTML = `<style>${style}</style>`
+
+  const btn = document.createElement('button')
+  btn.id = 'btn'
+  btn.setAttribute('aria-label', 'BibBot starten')
+  btn.innerHTML = '<span style="font-weight:700;color:white">B</span>'
+
+  shadow.appendChild(btn)
+
+  btn.addEventListener('click', (e) => {
+    e.preventDefault()
+    host.style.display = 'none'
+    if (siteBot.site.waitOnLoad) {
+      if (document.readyState === 'complete') {
+        siteBot.start(siteBot.site.waitOnLoad)
+      } else {
+        window.addEventListener('load', () => {
+          siteBot.start(siteBot.site.waitOnLoad)
+        })
+      }
+    } else {
+      siteBot.start()
+    }
+  })
+}
+
 if (site !== undefined) {
   const siteBot = new SiteBot(site, document.body, domain)
-  if (siteBot.site.waitOnLoad) {
-    if (document.readyState === 'complete') {
-      siteBot.start(siteBot.site.waitOnLoad)
-    } else {
-      window.addEventListener('load', () => {
-        siteBot.start(siteBot.site.waitOnLoad)
-      })
+  ;(async () => {
+    const items = await browser.storage.sync.get({ manualTrigger: false, disabledSites: [] })
+    if (items.disabledSites && items.disabledSites.includes(domain)) {
+      return
     }
-  } else {
-    siteBot.start()
-  }
+    if (items.manualTrigger) {
+      createFloatingButton(siteBot)
+    } else {
+      if (siteBot.site.waitOnLoad) {
+        if (document.readyState === 'complete') {
+          siteBot.start(siteBot.site.waitOnLoad)
+        } else {
+          window.addEventListener('load', () => {
+            siteBot.start(siteBot.site.waitOnLoad)
+          })
+        }
+      } else {
+        siteBot.start()
+      }
+    }
+  })()
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -42,7 +42,7 @@ function restore() {
     inputs.provider.value = items.provider
     inputs.keepStats.checked = items.keepStats
     inputs.saveArticle.value = items.saveArticle || ''
-    if (typeof inputs.manualTrigger !== 'undefined') {
+    if (typeof inputs.manualTrigger') {
       inputs.manualTrigger.checked = !!items.manualTrigger
     }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -42,7 +42,7 @@ function restore() {
     inputs.provider.value = items.provider
     inputs.keepStats.checked = items.keepStats
     inputs.saveArticle.value = items.saveArticle || ''
-    if (typeof inputs.manualTrigger') {
+    if (inputs.manualTrigger) {
       inputs.manualTrigger.checked = !!items.manualTrigger
     }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,7 @@ type InputOptions = {
   keepStats?: HTMLInputElement
   saveArticle?: HTMLInputElement
   disableSites?: HTMLSelectElement
+  manualTrigger?: HTMLInputElement
 }
 
 let currentPermissions: browser.Permissions.AnyPermissions | null = null
@@ -27,7 +28,7 @@ function showOptions() {
 
 function getInputs() {
   const inputs: InputOptions = {}
-  ;['provider', 'keepStats', 'saveArticle', 'disableSites'].forEach((id) => {
+  ;['provider', 'keepStats', 'saveArticle', 'disableSites', 'manualTrigger'].forEach((id) => {
     inputs[id] = <HTMLInputElement | HTMLSelectElement>(
       document.getElementById(id)
     )
@@ -41,6 +42,9 @@ function restore() {
     inputs.provider.value = items.provider
     inputs.keepStats.checked = items.keepStats
     inputs.saveArticle.value = items.saveArticle || ''
+    if (typeof inputs.manualTrigger !== 'undefined') {
+      inputs.manualTrigger.checked = !!items.manualTrigger
+    }
 
     if (items.providerOptions) {
       for (const providerKey in providers) {
@@ -176,6 +180,7 @@ function save() {
     providerOptions,
     saveArticle: inputs.saveArticle.value,
     disabledSites,
+    manualTrigger: !!inputs.manualTrigger && inputs.manualTrigger.checked,
   }
   if (!values.keepStats) {
     values.stats = {}

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -24,6 +24,7 @@ function retrieveStorage() {
       providerOptions: items.providerOptions,
       saveArticle: items.saveArticle,
       disabledSites: items.disabledSites,
+      manualTrigger: items.manualTrigger,
     }
   })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,7 @@ export interface BibbotOptions {
   providerOptions: ProviderStorageOptions
   saveArticle: string | null
   disabledSites: string[]
+  manualTrigger: boolean
 }
 
 export interface StorageItems extends BibbotOptions {


### PR DESCRIPTION
Ich habe hier ein PR erstellt um das Startverhalten, das automatische scrapen, um eine manuelle Variante zu ergänzen.
Wenn der manuelle Start in den Optionen:
<img width="749" height="193" alt="grafik" src="https://github.com/user-attachments/assets/764f121b-eb3a-4aed-892d-76f37045a9a5" />

aktiviert ist, erhält man auf der kompatiblen Webseite ein Icon:
<img width="119" height="100" alt="grafik" src="https://github.com/user-attachments/assets/c9b39045-a5be-4a32-bbed-a700271ecf41" />

Da ich selbst weder Typescript noch Addon Programmierung behersche, habe ich Github Copilot benutzt.
Denke, bis auf den Button, sieht der Code aber nicht schlecht aus.

Der Floating Button hat bisher nur ein B, ich konnte die SVG oder PNG jedoch nicht laden. Hier wäre das Icon von BibBot angebrachter.
z.B. 
`Sicherheitsfehler: Inhalt auf https://www.zeit.de/2021/11/soziale-ungleichheit-identitaetspolitik-diskriminierung-armut-bildung darf moz-extension://565b8935-5a19-4036-8b91-088d5d08b773/icons/bibbot-alpha-38.png nicht laden oder verlinken.
`

Das ist meine erste Modifikation eines Firefox Addons und da ich die Manifest Datei nicht zum laufen gebracht habe und immer diesen Fehler bekommen habe, habe ich die 0.40.8 von der Release Seite genommen habe und mit den neu erstelten Dateien aus /dist modifiziert habe.
Irgendwas mit dem background scripts war bei mir nicht ok ... Den Fehler habe ich leider nicht mehr in der Zwischenablage.
Oder auch, dass die Zip kein gültiges Manifest enthält, während ich das Addon temporär geladen habe.

Die Playwright Tests sind zum teil auch nicht richtig durchgelaufen...

Getestet habe ich meine Modifikation auf Windows unter Firefox 150.0.3 64Bit, immer als temp. Addon geladen.

**Wichtig** Auf Android konnte ich die Modifikation nicht testen. Was mein eigentlicher Anreiz war ... Da ich mit Google News oft in Paywalls laufe und vor dem ablaufen selbst entscheiden wollte. Daher weiß ich auch nicht wie der Button im Fennec/Firefox Android aussieht.