### PR TITLE
Add support for augsburger-allgemeine.de

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -110,7 +110,8 @@
         "https://www.saarbruecker-zeitung.de/*",
         "https://www.idowa.de/*",
         "https://www.aachener-zeitung.de/*",
-        "https://www.nn.de/*"
+        "https://www.nn.de/*",
+        "https://www.augsburger-allgemeine.de/*"
       ],
       "js": [
         "build/content.js"

--- a/src/sites.ts
+++ b/src/sites.ts
@@ -2,6 +2,7 @@ import {
   consentShadowRoot,
   getCmpBoxConsent,
   getConsentCdnSetup,
+  getContentPassConsent,
 } from './test_utils.js'
 
 import { PartialSite, Sites } from './types.js'
@@ -1723,6 +1724,28 @@ const sites: Sites = {
     sourceParams: {
       dbShortcut: 'NN',
       sourceNames: ['Nürnberger Nachrichten'],
+    },
+  },
+  'www.augsburger-allgemeine.de': {
+    testSetup: getContentPassConsent({}),
+    examples: [
+      {
+        url: 'https://www.augsburger-allgemeine.de/augsburg/nahverkehr-oepnv-augsburg-takt-city-zone-gratis-parkgebuehren-114901170',
+        selectors: {
+          query:
+            '"Entscheidung zur Zukunft des Nahverkehrs in Augsburg wird vor der Sommerpause nicht mehr"',
+        },
+      },
+    ],
+    selectors: {
+      query: makeQueryFunc('#article-body-paid-content > p'),
+      date: 'time',
+      paywall: '#piano-inline-paywall',
+      main: '#article-body-paid-content',
+    },
+    source: 'genios.de',
+    sourceParams: {
+      sourceNames: ['Augsburger Allgemeine'],
     },
   },
 }


### PR DESCRIPTION
## Summary
- Adds `www.augsburger-allgemeine.de` to `src/sites.ts`, bypassing the Piano paywall via the existing `genios.de` source (`sourceNames: ['Augsburger Allgemeine']`) — no new `Source` needed.
- Reuses the existing `getContentPassConsent` test helper for the site's consent gateway (its accept button uses the same "Akzeptieren und weiter" text, though it's actually a custom PD_PS/COPLA layer, not ContentPass).
- Adds `https://www.augsburger-allgemeine.de/*` to `manifest.json`'s `content_scripts.matches`.

## Test plan
- [x] `npm run check-types`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npx playwright test tests/sites.spec.ts -g "augsburger-allgemeine"` passes
- [x] Manually tested against the built extension (`dist.sh`) with a real Genios-backed provider login — paywall correctly bypassed on the example article


🤖 Generated with [Claude Code](https://claude.com/claude-code)