### PR TITLE
Wait for delayed provider search results

### DIFF
--- a/src/actiontarget.ts
+++ b/src/actiontarget.ts
@@ -1,0 +1,36 @@
+export const ACTION_TARGET_WAIT_MS = 10000
+const ACTION_TARGET_RETRY_MS = 100
+
+export function getFailOnMissingActionCode(
+  selector,
+  failure,
+  waitMs = ACTION_TARGET_WAIT_MS,
+) {
+  return {
+    func: (selector, attempts, retryMs) => {
+      const find = (remaining) => {
+        if (document.querySelector(selector) !== null) {
+          return Promise.resolve(true)
+        }
+        if (remaining === 0) {
+          return Promise.resolve(false)
+        }
+        return new Promise((resolve) => {
+          window.setTimeout(() => resolve(find(remaining - 1)), retryMs)
+        })
+      }
+      return find(attempts)
+    },
+    args: [
+      selector,
+      Math.ceil(waitMs / ACTION_TARGET_RETRY_MS),
+      ACTION_TARGET_RETRY_MS,
+    ],
+    resultFunc: (result) => {
+      if (result === true) {
+        return result
+      }
+      throw new Error(failure)
+    },
+  }
+}

--- a/src/tabrunner.ts
+++ b/src/tabrunner.ts
@@ -1,6 +1,7 @@
 import * as browser from 'webextension-polyfill'
 import { Action, ActionCode, Actions } from './types.js'
 
+import { getFailOnMissingActionCode } from './actiontarget.js'
 import { STATUS_MESSAGE } from './const.js'
 import converters from './converters.js'
 
@@ -85,16 +86,7 @@ class TabRunner {
         args: [action.event.selector, action.event.event],
       }
     } else if ('failOnMissing' in action) {
-      return {
-        func: (selector) => document.querySelector(selector) !== null,
-        args: [action.failOnMissing],
-        resultFunc: (result) => {
-          if (result === true) {
-            return result
-          }
-          throw new Error(action.failure)
-        },
-      }
+      return getFailOnMissingActionCode(action.failOnMissing, action.failure)
     } else if ('func' in action) {
       return {
         func: action.func,

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,8 +254,8 @@ export type ActionCode =
       args?: string[]
     }
   | {
-      func?: (...args: string[]) => boolean
-      args?: string[]
+      func?: (...args: (string | number)[]) => boolean | Promise<boolean>
+      args?: (string | number)[]
       resultFunc?: (result: boolean) => boolean
     }
   | {

--- a/tests/tabrunner.spec.ts
+++ b/tests/tabrunner.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test'
+import { getFailOnMissingActionCode } from '../src/actiontarget.js'
+
+const originalDocument = global.document
+const originalWindow = global.window
+
+test.afterEach(() => {
+  global.document = originalDocument
+  global.window = originalWindow
+})
+
+async function runFailOnMissing(availableAfter: number, waitMs: number) {
+  let queries = 0
+  global.document = {
+    querySelector: () => (++queries > availableAfter ? {} : null),
+  } as Document
+  global.window = {
+    setTimeout: (callback) => {
+      callback()
+      return 0
+    },
+  } as Window & typeof globalThis
+  const actionCode = getFailOnMissingActionCode(
+    '.result',
+    'Artikel nicht gefunden',
+    waitMs,
+  )
+  const result = actionCode.func(...actionCode.args)
+
+  return actionCode.resultFunc(await result)
+}
+
+test('waits for a delayed failOnMissing target', async () => {
+  await expect(runFailOnMissing(3, 300)).resolves.toBe(true)
+})
+
+test('uses the configured failure when a failOnMissing target stays absent', async () => {
+  await expect(runFailOnMissing(Infinity, 10)).rejects.toThrow(
+    'Artikel nicht gefunden',
+  )
+})


### PR DESCRIPTION
## What changed

`failOnMissing` now checks for its target every 100 ms for up to 10 seconds. If the target appears during that window, the source flow continues. If it remains absent, the action still raises its configured failure message.

## Why

GENIOS can finish the document load before its result cards are rendered. BibBot previously checked `.tooltip.article__text__title` once, immediately after the provider tab reported that it had loaded. The same search could therefore report `Artikel nicht gefunden` even though the matching result appeared once the page finished rendering.

The wait is implemented for `failOnMissing` generally; there are no site- or publisher-specific conditions.

## Checks

- `npx playwright test tests/tabrunner.spec.ts`
- `npm run lint`
- `npm run check-types`
- `npm run build`

The tests cover both a delayed target and a target that remains absent through the wait.
